### PR TITLE
Switching from using Ansible's firewalld port_forward to rich_rules

### DIFF
--- a/playbooks/base_virt.yml
+++ b/playbooks/base_virt.yml
@@ -270,11 +270,7 @@
 
     - name: Enable port 9001 forwarding to bastion:9001 with firewalld
       firewalld:
-        port_forward:
-          port: "9001"
-          proto: tcp
-          toaddr: 192.168.123.100
-          toport: "9001"
+        rich_rule: rule family=ipv4 forward-port port=9001 protocol=tcp to-addr=192.168.123.100 to-port=9001
         zone: public
         permanent: yes
         state: enabled

--- a/playbooks/prebuilt/destroy_infra.yml
+++ b/playbooks/prebuilt/destroy_infra.yml
@@ -217,14 +217,10 @@
 
     - name: Disable port 9001 forwarding to bastion:9001 with firewalld
       firewalld:
-        port_forward:
-          port:	"9001"
-          proto: tcp
-          toaddr: 192.168.123.100
-          toport: "9001"
+        rich_rule: rule family=ipv4 forward-port port=9001 protocol=tcp to-addr=192.168.123.100 to-port=9001
         zone: public
         permanent: yes
-        state: absent
+        state: disabled
       when:
         - firewalld_avail.rc != 4
 


### PR DESCRIPTION
This will allow to use Ansible 2.9 which is officially supported by Red Hat. Firewalld module from Ansible 2.9 does not support port_forward parameter.